### PR TITLE
Add directory support to smbc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,6 @@
 //!
 //! Files are represented by [`SmbFile`](struct.SmbFile.html).
 //!
-//! Basic example:
-//! ```rust
-//! fn load
-//! # fn main() {}
-//! ```
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
I've never done samba development before so I don't really know if this is correct.  I have however done a bunch of filesystem work and these calls are similar.  It looked like the codebase took great care to not allocate unnecessary things.  If you'd like me to try and do the same I can try and remove String and PathBuf from the directory struct.  I'm going to setup a local samba on a virtual machine and give this a test with valgrind to make sure i'm not leaking anything.  